### PR TITLE
Missing composer autoload section and Show() cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,10 @@
 	],
     "require": {
         "php": ">=5.3.0"
+    },
+    "autoload": {
+        "files": [
+            "src/PHPImage.php"
+        ]
     }
 }

--- a/src/PHPImage.php
+++ b/src/PHPImage.php
@@ -523,28 +523,24 @@ class PHPImage {
 	}
 
 	/**
-	 * Shows the resulting image
+	 * Shows the resulting image and cleans up.
 	 */
 	public function show(){
-		header('Expires: Wed, 1 Jan 1997 00:00:00 GMT');
-		header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
-		header('Cache-Control: no-store, no-cache, must-revalidate');
-		header('Cache-Control: post-check=0, pre-check=0', false);
-		header('Pragma: no-cache');
-		header('Content-type: image/png');
 		switch($this->type){
 			case IMAGETYPE_GIF:
+				header('Content-type: image/gif');
 				imagegif($this->img, null);
 				break;
 			case IMAGETYPE_PNG:
+				header('Content-type: image/png');
 				imagepng($this->img, null, $this->quality);
 				break;
 			default:
+				header('Content-type: image/jpeg');
 				imagejpeg($this->img, null, $this->quality);
 				break;
 		}
 		$this->cleanup();
-		die();
 	}
 
 	/**


### PR DESCRIPTION
Wasn't able to get to the PHPImage class after I added it to composer. Needed to add the autoload section for it to work (unless I've missed something...).

Also cleaned up the `Show()` function, which in my opinion did more than it should. Caching headers and dying can better be taken care of outside the class. Additionally it was only setting the `image/jpeg` header, if I read it correctly. Fixed that too :)
