### PR TITLE
Added case for PHPImage instance to getImageInfo

### DIFF
--- a/src/PHPImage.php
+++ b/src/PHPImage.php
@@ -224,6 +224,26 @@ class PHPImage {
 		imagecopy($this->img, $this->img_copy, 0, 0, 0, 0, $this->width, $this->height);
 	}
 
+
+	/**
+	 * Get image height
+	 *
+	 * @return int
+	 */
+	public function getHeight(){
+		return $this->height;
+	}
+
+	/**
+	 * Get image width
+	 *
+	 * @return int
+	 */
+	public function getWidth(){
+		return $this->width;
+	}
+	
+
 	/**
 	 * Get image resource (used when using a raw gd command)
 	 *

--- a/src/PHPImage.php
+++ b/src/PHPImage.php
@@ -267,7 +267,12 @@ class PHPImage {
 	 * @return \stdClass
 	 */
 	protected function getImageInfo($file, $returnResource=true){
-		if (preg_match('#^https?://#i', $file)) {
+		if($file instanceof PHPIMage) {
+			$img = $file->img;
+			$type = $file->type;
+			$width = $file->width;
+			$height = $file->height;
+		} elseif (preg_match('#^https?://#i', $file)) {
 			$headers = get_headers($file, 1);
 			if (is_array($headers['Content-Type'])) {
 				// Some servers return an array of content types, Facebook does this


### PR DESCRIPTION
Seems to allow for `draw()`-ing directly from another instance of PHPImage... which I needed to be able to resize an image first, without writing it out to a file. Guess issue #4 is about that well...?

The following seems to work at least after this change:

```
    $thumb = new PHPImage('some image.png');
    $thumb->resize(200, 200, false, true);
    $image->draw($thumb, 'center', 'center');
```
